### PR TITLE
Fix pub/sub feature expecting the packet to be non-empty list

### DIFF
--- a/lib/src/redis_connection.dart
+++ b/lib/src/redis_connection.dart
@@ -120,7 +120,7 @@ class RedisConnection {
 
     _stream?.listen((dynamic packet) {
       /// If packet is from pub/sub
-      if (packet is List && packet[0] == 'message') {
+      if (packet is List && packet.isNotEmpty && packet[0] == 'message') {
         String channel = packet[1];
         String message = packet[2];
         RedisSubscriber? cb = _findSubscribeListener(channel);


### PR DESCRIPTION
Stream listener incorrectly expects that the incoming packet is always non-empty. This is not always the case, for example when calling `SMEMBERS` and it returns no results, the packet would be empty list and the index access fails.